### PR TITLE
Bug: AuditAware 토큰이 필요없는 요청에서도 작동

### DIFF
--- a/src/main/java/com/kurly/pip/config/audit/MemberAuditorAware.java
+++ b/src/main/java/com/kurly/pip/config/audit/MemberAuditorAware.java
@@ -4,22 +4,19 @@ import java.util.Optional;
 
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-
-import com.kurly.pip.entity.member.Member;
 
 @Component
 class MemberAuditorAware implements AuditorAware<Long> {
 
     @Override
     public Optional<Long> getCurrentAuditor() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication == null || !authentication.isAuthenticated()) {
-            return null;
-        }
-
-        return Optional.of(((Member)authentication.getPrincipal()).getId());
+        return Optional.ofNullable(SecurityContextHolder.getContext())
+            .map(SecurityContext::getAuthentication)
+            .filter(authentication -> !authentication.getPrincipal().equals("anonymousUser"))
+            .map(Authentication::getPrincipal)
+            .map(Long.class::cast);
     }
 }


### PR DESCRIPTION
## ✔️ PR 타입

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 버그 수정

## 📃 개요
- 토큰이 필요없는 요청에서도 Audit Aware 기능이 작동하여, 토큰에 ID가 없다는 예외가 발생

## ✏️ 변경사항
- 토큰이 없는 요청일 경우 필터를 통해 제외하는 로직 추가
## 🫥 TODO
